### PR TITLE
Organize files into purpose-based folder

### DIFF
--- a/app/src/main/java/com/example/movieapp/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/movieapp/di/UseCaseModule.kt
@@ -2,12 +2,12 @@ package com.example.movieapp.di
 
 import com.example.domain.repository.AuthRepository
 import com.example.domain.repository.MovieRepository
-import com.example.domain.usecase.GetMovieUseCase
-import com.example.domain.usecase.GetPopularMoviesUseCase
-import com.example.domain.usecase.LoginUseCase
-import com.example.domain.usecase.impl.GetMovieUseCaseImpl
-import com.example.domain.usecase.impl.GetPopularMoviesUseCaseImpl
-import com.example.domain.usecase.impl.LoginUseCaseImpl
+import com.example.domain.usecase.getmovie.GetMovieUseCase
+import com.example.domain.usecase.getmovie.GetMovieUseCaseImpl
+import com.example.domain.usecase.getpopularmovie.GetPopularMoviesUseCase
+import com.example.domain.usecase.getpopularmovie.GetPopularMoviesUseCaseImpl
+import com.example.domain.usecase.login.LoginUseCase
+import com.example.domain.usecase.login.LoginUseCaseImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/app/src/main/java/com/example/movieapp/fragment/listmovie/ListMovieViewModel.kt
+++ b/app/src/main/java/com/example/movieapp/fragment/listmovie/ListMovieViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import com.example.data.network.DispatcherProvider
-import com.example.domain.usecase.GetPopularMoviesUseCase
+import com.example.domain.usecase.getpopularmovie.GetPopularMoviesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject

--- a/app/src/main/java/com/example/movieapp/fragment/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/movieapp/fragment/login/LoginViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.data.network.DispatcherProvider
 import com.example.domain.either.Either
-import com.example.domain.usecase.LoginUseCase
+import com.example.domain.usecase.login.LoginUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/example/movieapp/fragment/moviedetail/MovieDetailViewModel.kt
+++ b/app/src/main/java/com/example/movieapp/fragment/moviedetail/MovieDetailViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.data.network.DispatcherProvider
 import com.example.domain.either.Either
-import com.example.domain.usecase.GetMovieUseCase
+import com.example.domain.usecase.getmovie.GetMovieUseCase
 import com.example.movieapp.fragment.moviedetail.state.MovieState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/data/src/main/java/com/example/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/example/data/di/RepositoryModule.kt
@@ -1,9 +1,9 @@
 package com.example.data.di
 
 import com.example.data.database.datasource.LocalMovieDataSource
-import com.example.data.network.api.MovieService
-import com.example.data.repository.impl.AuthRepositoryImpl
-import com.example.data.repository.impl.MovieRepositoryImpl
+import com.example.data.service.movie.MovieService
+import com.example.data.repository.AuthRepositoryImpl
+import com.example.data.repository.MovieRepositoryImpl
 import com.example.domain.repository.AuthRepository
 import com.example.domain.repository.MovieRepository
 import dagger.Module

--- a/data/src/main/java/com/example/data/di/ServiceModule.kt
+++ b/data/src/main/java/com/example/data/di/ServiceModule.kt
@@ -1,8 +1,8 @@
 package com.example.data.di
 
 import com.example.data.network.api.MovieApi
-import com.example.data.network.api.MovieService
-import com.example.data.network.api.impl.MovieServiceImpl
+import com.example.data.service.movie.MovieService
+import com.example.data.service.movie.MovieServiceImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/data/src/main/java/com/example/data/paging/MoviePagingSource.kt
+++ b/data/src/main/java/com/example/data/paging/MoviePagingSource.kt
@@ -4,7 +4,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.example.data.BuildConfig
 import com.example.data.mapper.toMovieEntity
-import com.example.data.network.api.MovieService
+import com.example.data.service.movie.MovieService
 import com.example.domain.entity.MovieEntity
 import javax.inject.Inject
 

--- a/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.example.data.repository.impl
+package com.example.data.repository
 
 import com.example.data.mapper.toNetworkErrorEntity
 import com.example.domain.either.Either

--- a/data/src/main/java/com/example/data/repository/MovieRepositoryImpl.kt
+++ b/data/src/main/java/com/example/data/repository/MovieRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.example.data.repository.impl
+package com.example.data.repository
 
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
@@ -9,7 +9,7 @@ import com.example.data.database.model.MovieRecord
 import com.example.data.mapper.toDatabaseErrorEntity
 import com.example.data.mapper.toMovieEntity
 import com.example.data.mapper.toMovieRecord
-import com.example.data.network.api.MovieService
+import com.example.data.service.movie.MovieService
 import com.example.data.paging.MoviePagingSource
 import com.example.domain.either.Either
 import com.example.domain.entity.MovieEntity

--- a/data/src/main/java/com/example/data/service/movie/MovieService.kt
+++ b/data/src/main/java/com/example/data/service/movie/MovieService.kt
@@ -1,4 +1,4 @@
-package com.example.data.network.api
+package com.example.data.service.movie
 
 import com.example.data.network.model.MovieDto
 import com.example.data.network.response.BaseListResponse

--- a/data/src/main/java/com/example/data/service/movie/MovieServiceImpl.kt
+++ b/data/src/main/java/com/example/data/service/movie/MovieServiceImpl.kt
@@ -1,7 +1,6 @@
-package com.example.data.network.api.impl
+package com.example.data.service.movie
 
 import com.example.data.network.api.MovieApi
-import com.example.data.network.api.MovieService
 import com.example.data.network.model.MovieDto
 import com.example.data.network.response.BaseListResponse
 import javax.inject.Inject

--- a/domain/src/main/java/com/example/domain/usecase/getmovie/GetMovieUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/getmovie/GetMovieUseCase.kt
@@ -1,4 +1,4 @@
-package com.example.domain.usecase
+package com.example.domain.usecase.getmovie
 
 import com.example.domain.either.Either
 import com.example.domain.entity.MovieEntity

--- a/domain/src/main/java/com/example/domain/usecase/getmovie/GetMovieUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/getmovie/GetMovieUseCaseImpl.kt
@@ -1,10 +1,9 @@
-package com.example.domain.usecase.impl
+package com.example.domain.usecase.getmovie
 
 import com.example.domain.either.Either
 import com.example.domain.entity.MovieEntity
 import com.example.domain.error.ErrorEntity
 import com.example.domain.repository.MovieRepository
-import com.example.domain.usecase.GetMovieUseCase
 import javax.inject.Inject
 
 class GetMovieUseCaseImpl @Inject constructor(

--- a/domain/src/main/java/com/example/domain/usecase/getpopularmovie/GetPopularMoviesUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/getpopularmovie/GetPopularMoviesUseCase.kt
@@ -1,4 +1,4 @@
-package com.example.domain.usecase
+package com.example.domain.usecase.getpopularmovie
 
 import androidx.paging.PagingData
 import com.example.domain.entity.MovieEntity

--- a/domain/src/main/java/com/example/domain/usecase/getpopularmovie/GetPopularMoviesUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/getpopularmovie/GetPopularMoviesUseCaseImpl.kt
@@ -1,9 +1,9 @@
-package com.example.domain.usecase.impl
+package com.example.domain.usecase.getpopularmovie
 
 import androidx.paging.PagingData
 import com.example.domain.entity.MovieEntity
 import com.example.domain.repository.MovieRepository
-import com.example.domain.usecase.GetPopularMoviesUseCase
+import com.example.domain.usecase.getpopularmovie.GetPopularMoviesUseCase
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 

--- a/domain/src/main/java/com/example/domain/usecase/login/LoginUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/login/LoginUseCase.kt
@@ -1,4 +1,4 @@
-package com.example.domain.usecase
+package com.example.domain.usecase.login
 
 import com.example.domain.either.Either
 import com.example.domain.entity.UserEntity

--- a/domain/src/main/java/com/example/domain/usecase/login/LoginUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/login/LoginUseCaseImpl.kt
@@ -1,10 +1,9 @@
-package com.example.domain.usecase.impl
+package com.example.domain.usecase.login
 
 import com.example.domain.either.Either
 import com.example.domain.entity.UserEntity
 import com.example.domain.error.ErrorEntity
 import com.example.domain.repository.AuthRepository
-import com.example.domain.usecase.LoginUseCase
 import javax.inject.Inject
 
 private const val USER_LIMIT_LENGTH = 4

--- a/moviecomposeapp/src/main/java/com/example/moviecomposeapp/di/UseCaseModule.kt
+++ b/moviecomposeapp/src/main/java/com/example/moviecomposeapp/di/UseCaseModule.kt
@@ -2,12 +2,12 @@ package com.example.moviecomposeapp.di
 
 import com.example.domain.repository.AuthRepository
 import com.example.domain.repository.MovieRepository
-import com.example.domain.usecase.GetMovieUseCase
-import com.example.domain.usecase.GetPopularMoviesUseCase
-import com.example.domain.usecase.LoginUseCase
-import com.example.domain.usecase.impl.GetMovieUseCaseImpl
-import com.example.domain.usecase.impl.GetPopularMoviesUseCaseImpl
-import com.example.domain.usecase.impl.LoginUseCaseImpl
+import com.example.domain.usecase.getmovie.GetMovieUseCase
+import com.example.domain.usecase.getpopularmovie.GetPopularMoviesUseCase
+import com.example.domain.usecase.login.LoginUseCase
+import com.example.domain.usecase.getmovie.GetMovieUseCaseImpl
+import com.example.domain.usecase.getpopularmovie.GetPopularMoviesUseCaseImpl
+import com.example.domain.usecase.login.LoginUseCaseImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/moviecomposeapp/src/main/java/com/example/moviecomposeapp/screen/listmovie/ListMovieViewModel.kt
+++ b/moviecomposeapp/src/main/java/com/example/moviecomposeapp/screen/listmovie/ListMovieViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import com.example.data.network.DispatcherProvider
-import com.example.domain.usecase.GetPopularMoviesUseCase
+import com.example.domain.usecase.getpopularmovie.GetPopularMoviesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject

--- a/moviecomposeapp/src/main/java/com/example/moviecomposeapp/screen/login/LoginViewModel.kt
+++ b/moviecomposeapp/src/main/java/com/example/moviecomposeapp/screen/login/LoginViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.data.network.DispatcherProvider
 import com.example.domain.either.Either
-import com.example.domain.usecase.LoginUseCase
+import com.example.domain.usecase.login.LoginUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/moviecomposeapp/src/main/java/com/example/moviecomposeapp/screen/moviedetail/MovieDetailViewModel.kt
+++ b/moviecomposeapp/src/main/java/com/example/moviecomposeapp/screen/moviedetail/MovieDetailViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.data.network.DispatcherProvider
 import com.example.domain.either.Either
-import com.example.domain.usecase.GetMovieUseCase
+import com.example.domain.usecase.getmovie.GetMovieUseCase
 import com.example.moviecomposeapp.screen.moviedetail.state.MovieState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow


### PR DESCRIPTION
Put some interfaces and their implementation into same a same folder, basing on their purpose. E.g `LoginUseCase` and `LoginUseCaseImpl` are put under `usecase.login` folder.